### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://codedev.ms/v-wexu1/9ab3f4f9-b166-4515-8fde-0be3ca4e8a82/11f944fe-3b05-4880-8643-47f07e3a16fe/_apis/work/boardbadge/c0125113-029c-4c01-ac19-11cc86b0bcfd)](https://codedev.ms/v-wexu1/9ab3f4f9-b166-4515-8fde-0be3ca4e8a82/_boards/board/t/11f944fe-3b05-4880-8643-47f07e3a16fe/Microsoft.RequirementCategory)
 # A1
 ygsdiu fuhgl


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://codedev.ms/v-wexu1/9ab3f4f9-b166-4515-8fde-0be3ca4e8a82/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.